### PR TITLE
Services upgrade

### DIFF
--- a/env/additional/elasticsearch7/Dockerfile
+++ b/env/additional/elasticsearch7/Dockerfile
@@ -1,3 +1,3 @@
 # https://www.elastic.co/guide/en/elasticsearch/reference/6.5/docker.html#docker
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.3
 COPY --chown=elasticsearch:elasticsearch config/elasticsearch.yml /usr/share/elasticsearch/config/

--- a/env/additional/rabbitmq/docker-compose.yml
+++ b/env/additional/rabbitmq/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
   rabbitmq:
     container_name: magento2rabbitmq
-    image: rabbitmq:3.6-management
+    image: rabbitmq:3.8-management
     restart: always
     ports:
             - "15672:15672"

--- a/env/additional/redis/docker-compose.yml
+++ b/env/additional/redis/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
   redis:
     container_name: magento2redis
-    image: redis:3.2
+    image: redis:6.0
 networks:
   default:
     external:

--- a/env/docker-compose.yml
+++ b/env/docker-compose.yml
@@ -23,7 +23,8 @@ services:
       - "SYS_PTRACE"
   db:
     container_name: magento2db
-    image: mysql:5.7
+    # MariaDB is most common in Cloud
+    image: mariadb:10.2
     restart: always
     environment:
       MYSQL_DATABASE: magento


### PR DESCRIPTION
- elastic7: upgrade from 7..6.2 to 7.16.3
- rabbitmq: upgrade from 3.6 to 3.8
- redis: upgrade from 3.2 to 6.0
- db: upgrade from MySQL 5.7 to MariaDB 10.2