### PR TITLE
Adjustments for Apple M1 chips

### DIFF
--- a/env/additional/elasticsearch6/docker-compose.yml
+++ b/env/additional/elasticsearch6/docker-compose.yml
@@ -3,6 +3,8 @@ version: '2'
 services:
   elasticsearch:
     container_name: magento2elastic6
+    # for ES 6 there is no official image for arm-v8 (Apple M1) so we need to force different platform and image will work with emulation (WARNING: will be slow)
+    platform: linux/x86_64
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     build: .

--- a/env/additional/elasticsearch7/Dockerfile
+++ b/env/additional/elasticsearch7/Dockerfile
@@ -1,3 +1,3 @@
 # https://www.elastic.co/guide/en/elasticsearch/reference/6.5/docker.html#docker
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.3
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.3-arm64
 COPY --chown=elasticsearch:elasticsearch config/elasticsearch.yml /usr/share/elasticsearch/config/

--- a/env/additional/varnish/docker-compose.yml
+++ b/env/additional/varnish/docker-compose.yml
@@ -3,7 +3,11 @@ version: '2'
 services:
   varnish:
     container_name: magento2varnish
+    # for Varnis 6 there is no official image for arm-v8 (Apple M1) so we need to force different platform and image will work with emulation (WARNING: will be slow)
+    platform: linux/x86_64
     image: varnish:6.5
+    # for MAgento 2.4.4 and up, comment out the above two lines and uncomment the below one for better performance
+    # image: varnish:7.0
     ports:
       - "8080:8080"
 networks:


### PR DESCRIPTION
- ElasticSearch 6: forcing platform to x86_64
- ElasticSearch 7: using better image
- Varnish: forcing platform to x86_64 and adding an image for Magento 2.4.4 and up as an option