### PR TITLE
RC 2.1.0

### DIFF
--- a/env/.env.example
+++ b/env/.env.example
@@ -1,3 +1,4 @@
 MAGENTO_CLOUD_CLI_TOKEN=
 COMPOSER_AUTH={"http-basic":{"repo.magento.com":{"username":"","password":""}}}
 M2D_XDEBUG_IDE_KEY=PHPSTORM
+M2D_OPENSEARCH_MAX_HEAP_SIZE=512m

--- a/env/.env.example
+++ b/env/.env.example
@@ -1,2 +1,3 @@
 MAGENTO_CLOUD_CLI_TOKEN=
 COMPOSER_AUTH={"http-basic":{"repo.magento.com":{"username":"","password":""}}}
+M2D_XDEBUG_IDE_KEY=PHPSTORM

--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -1,5 +1,5 @@
 #PHP IMAGE
-FROM php:7.4-apache-buster
+FROM php:7.4-apache-bullseye
 
 #SETTING UP THE SYSTEM
 RUN apt-get update \

--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -83,13 +83,15 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 RUN ln -s /usr/local/bin/composer1 /usr/local/bin/composer
 
 #XDEBUG
+ARG M2D_XDEBUG_IDE_KEY=PHPSTORM
+ENV M2D_XDEBUG_IDE_KEY=${M2D_XDEBUG_IDE_KEY:-PHPSTORM}
 RUN pecl install xdebug-2.9.0 \
     && echo ";zend_extension=xdebug.so" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_autostart=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.max_nesting_level=10000" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-    && echo "xdebug.idekey=PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+    && echo "xdebug.idekey=$M2D_XDEBUG_IDE_KEY" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 COPY ./misc/xdebug-php.sh /usr/local/bin/xdebug-php.sh
 COPY ./misc/prepare-mtf.sh /usr/local/bin/prepare-mtf.sh
 COPY ./misc/composer-link.sh /usr/local/bin/composer-link.sh

--- a/env/Makefile
+++ b/env/Makefile
@@ -133,6 +133,14 @@ logs-elastic7:
 	docker logs -f magento2elastic7
 elastic7-stop:
 	cd additional/elasticsearch7 && docker-compose stop && cd -
+opensearch:
+	cd additional/opensearch && docker-compose up -d && cd -
+	# Web interface:
+	# http://127.0.0.1:9200
+logs-opensearch:
+	docker logs -f magento2opensearch
+opensearch-stop:
+	cd additional/opensearch && docker-compose stop && cd -
 selenium:
 	cd additional/selenium && docker-compose up -d && cd -
 	# VNC open vnc://:secret@127.0.0.1:5900

--- a/env/additional/opensearch/docker-compose.yaml
+++ b/env/additional/opensearch/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+  opensearch:
+    image: opensearchproject/opensearch:1.2.4
+    container_name: magento2opensearch
+    environment:
+      - "discovery.type=single-node"
+      - "plugins.security.disabled=true"
+      - "http.host=0.0.0.0"
+      - "http.port=9200"
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx${M2D_OPENSEARCH_MAX_HEAP_SIZE:-512m}"
+      - "DISABLE_INSTALL_DEMO_CONFIG=true" # disable demo config see https://opensearch.org/docs/latest/opensearch/install/docker-security/
+    ports:
+      - "9200:9200"
+networks:
+  default:
+    name: env_default
+    external: true

--- a/env/additional/rabbitmq/docker-compose.yml
+++ b/env/additional/rabbitmq/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   rabbitmq:
     container_name: magento2rabbitmq
     image: rabbitmq:3.8-management
-    restart: always
+    restart: unless-stopped
     ports:
             - "15672:15672"
 networks:

--- a/env/docker-compose.yml
+++ b/env/docker-compose.yml
@@ -5,7 +5,10 @@ services:
     hostname: magento2.test
     container_name: magento2web
     restart: unless-stopped
-    build: .
+    build:
+      context: .
+      args:
+        - M2D_XDEBUG_IDE_KEY=${M2D_XDEBUG_IDE_KEY:-PHPSTORM}
     environment:
       - PHP_IDE_CONFIG=serverName=PHPSTORM
       - BLACKFIRE_CLIENT_ID

--- a/env/docker-compose.yml
+++ b/env/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   web:
     hostname: magento2.test
     container_name: magento2web
-    restart: always
+    restart: unless-stopped
     build: .
     environment:
       - PHP_IDE_CONFIG=serverName=PHPSTORM
@@ -27,7 +27,7 @@ services:
     container_name: magento2db
     # MariaDB is most common in Cloud
     image: mariadb:10.2
-    restart: always
+    restart: unless-stopped
     environment:
       MYSQL_DATABASE: magento
       MYSQL_ALLOW_EMPTY_PASSWORD: 1

--- a/env/etc/php/7.3/Dockerfile
+++ b/env/etc/php/7.3/Dockerfile
@@ -78,13 +78,15 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
     && apt -qy install $PHPIZE_DEPS && mkdir /${_HOME_DIRECTORY}/.composer
 
 #XDEBUG
+ARG M2D_XDEBUG_IDE_KEY=PHPSTORM
+ENV M2D_XDEBUG_IDE_KEY=${M2D_XDEBUG_IDE_KEY:-PHPSTORM}
 RUN pecl install xdebug-2.9.0 \
     && echo ";zend_extension=xdebug.so" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_autostart=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.max_nesting_level=10000" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-    && echo "xdebug.idekey=PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+    && echo "xdebug.idekey=$M2D_XDEBUG_IDE_KEY" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 COPY ./misc/xdebug-php.sh /usr/local/bin/xdebug-php.sh
 
 #CODESNIFFER

--- a/env/etc/php/7.3/Dockerfile
+++ b/env/etc/php/7.3/Dockerfile
@@ -1,5 +1,5 @@
 #PHP IMAGE
-FROM php:7.3-apache-stretch
+FROM php:7.3-apache-bullseye
 
 #SETTING UP THE SYSTEM
 RUN apt-get update \

--- a/env/etc/php/7.4/Dockerfile
+++ b/env/etc/php/7.4/Dockerfile
@@ -1,5 +1,5 @@
 #PHP IMAGE
-FROM php:7.4-apache-buster
+FROM php:7.4-apache-bullseye
 
 #SETTING UP THE SYSTEM
 RUN apt-get update \

--- a/env/etc/php/7.4/Dockerfile
+++ b/env/etc/php/7.4/Dockerfile
@@ -83,13 +83,15 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 RUN ln -s /usr/local/bin/composer1 /usr/local/bin/composer
 
 #XDEBUG
+ARG M2D_XDEBUG_IDE_KEY=PHPSTORM
+ENV M2D_XDEBUG_IDE_KEY=${M2D_XDEBUG_IDE_KEY:-PHPSTORM}
 RUN pecl install xdebug-2.9.0 \
     && echo ";zend_extension=xdebug.so" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_autostart=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.max_nesting_level=10000" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-    && echo "xdebug.idekey=PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+    && echo "xdebug.idekey=$M2D_XDEBUG_IDE_KEY" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 COPY ./misc/xdebug-php.sh /usr/local/bin/xdebug-php.sh
 COPY ./misc/prepare-mtf.sh /usr/local/bin/prepare-mtf.sh
 COPY ./misc/composer-link.sh /usr/local/bin/composer-link.sh

--- a/env/etc/php/8.0/Dockerfile
+++ b/env/etc/php/8.0/Dockerfile
@@ -1,5 +1,5 @@
 #PHP IMAGE
-FROM php:8.0-apache-buster
+FROM php:8.0-apache-bullseye
 
 #SETTING UP THE SYSTEM
 RUN apt-get update \

--- a/env/etc/php/8.0/Dockerfile
+++ b/env/etc/php/8.0/Dockerfile
@@ -82,13 +82,15 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 RUN ln -s /usr/local/bin/composer2 /usr/local/bin/composer
 
 #XDEBUG
+ARG M2D_XDEBUG_IDE_KEY=PHPSTORM
+ENV M2D_XDEBUG_IDE_KEY=${M2D_XDEBUG_IDE_KEY:-PHPSTORM}
 RUN pecl install xdebug-3.0.1 \
     && echo ";zend_extension=xdebug.so" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_autostart=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.max_nesting_level=10000" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-    && echo "xdebug.idekey=PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+    && echo "xdebug.idekey=$M2D_XDEBUG_IDE_KEY" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 COPY ./misc/xdebug-php.sh /usr/local/bin/xdebug-php.sh
 COPY ./misc/composer-link.sh /usr/local/bin/composer-link.sh
 

--- a/env/etc/php/8.1/Dockerfile
+++ b/env/etc/php/8.1/Dockerfile
@@ -1,5 +1,5 @@
 #PHP IMAGE
-FROM php:8.1-apache-buster
+FROM php:8.1-apache-bullseye
 
 #SETTING UP THE SYSTEM
 RUN apt-get update \

--- a/env/etc/php/8.1/Dockerfile
+++ b/env/etc/php/8.1/Dockerfile
@@ -81,13 +81,15 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 RUN ln -s /usr/local/bin/composer2 /usr/local/bin/composer
 
 #XDEBUG
+ARG M2D_XDEBUG_IDE_KEY=PHPSTORM
+ENV M2D_XDEBUG_IDE_KEY=${M2D_XDEBUG_IDE_KEY:-PHPSTORM}
 RUN pecl install xdebug \
     && echo ";zend_extension=xdebug.so" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.max_nesting_level=10000" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-    && echo "xdebug.idekey=PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+    && echo "xdebug.idekey=$M2D_XDEBUG_IDE_KEY" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 COPY ./misc/xdebug-php.sh /usr/local/bin/xdebug-php.sh
 
 # COMPOSER VERSION SWITCHER


### PR DESCRIPTION
Features:

- Prevent containers from starting if stopped manually. Instead of using restart -> always, it is restart -> unless-stopped. This way, when a container is stopped manually, it will not be restarted automatically. This will also prevent containers from autostarting on docker start.
- Makes the xDebug idekey option configurable from docker-compose. Now you can change idekey from PHPSTORM to VSCODE or anything else just by configuring it in .env file or by defying the value for the M2D_XDEBUG_IDE_KEY environment variable.
- Unify base image accros php versions. Now all PHP containers are based on apache-bullseye.
- Added OpenSearch 1.2.4. Max heap size can be configured with the M2D_OPENSEARCH_MAX_HEAP_SIZE variable.